### PR TITLE
(bugfix): Remove over-calculation of scores Student scores were wrong…

### DIFF
--- a/Students/XhiChun_details.txt
+++ b/Students/XhiChun_details.txt
@@ -1,0 +1,2 @@
+Name: Liew Xhi Chun
+I am taking Code Management in DevOps!

--- a/Students/XhiChun_details.txt
+++ b/Students/XhiChun_details.txt
@@ -1,2 +1,2 @@
 Name: Liew Xhi Chun
-I am taking Code Management in DevOps!
+I am taking Code Management in DevOps!!

--- a/Students/student_details.txt
+++ b/Students/student_details.txt
@@ -2,9 +2,9 @@ There are 6 students in total for this class.
 For each student, we will store their names and current score for the class.
 The students are currently arranged based on decreasing order of their score.
 
-1. James (91%)
-2. Tim (83%)
-3. Samantha (81%)
-4. Paul (75%)
-5. Rea (70%)
-6. Lenny (66%)
+1. James (90%)
+2. Tim (82%)
+3. Samantha (80%)
+4. Paul (74%)
+5. Rea (69%)
+6. Lenny (65%)

--- a/Students/student_details.txt
+++ b/Students/student_details.txt
@@ -3,8 +3,9 @@ For each student, we will store their names and current score for the class.
 The students are currently arranged based on decreasing order of their score.
 
 1. James (91%)
-2. Tim (83%)
-3. Samantha (81%)
-4. Paul (75%)
-5. Rea (70%)
-6. Lenny (66%)
+2. XhiChun (85%)
+3. Tim (83%)
+4. Samantha (81%)
+5. Paul (75%)
+6. Rea (70%)
+7. Lenny (66%)

--- a/Students/student_details.txt
+++ b/Students/student_details.txt
@@ -3,7 +3,7 @@ For each student, we will store their names and current score for the class.
 The students are currently arranged based on decreasing order of their score.
 
 1. James (91%)
-2. XhiChun (85%)
+2. XhiChun (85%))
 3. Tim (83%)
 4. Samantha (81%)
 5. Paul (75%)

--- a/Students/student_details.txt
+++ b/Students/student_details.txt
@@ -3,7 +3,7 @@ For each student, we will store their names and current score for the class.
 The students are currently arranged based on decreasing order of their score.
 
 1. James (91%)
-2. Xhi Chun (85%)
+2. XhiChun (85%)
 3. Tim (83%)
 4. Samantha (81%)
 5. Paul (75%)

--- a/Students/student_details.txt
+++ b/Students/student_details.txt
@@ -3,7 +3,7 @@ For each student, we will store their names and current score for the class.
 The students are currently arranged based on decreasing order of their score.
 
 1. James (91%)
-2. XhiChun (85%))
+2. Xhi Chun (85%)
 3. Tim (83%)
 4. Samantha (81%)
 5. Paul (75%)


### PR DESCRIPTION
…ly calculated initially and were each higher than their actual score by 1. The actual score is now updated with the correct values.