### PR TITLE
(bugfix): Remove over-calculation of scores

### DIFF
--- a/Students/Erdawati_details.txt
+++ b/Students/Erdawati_details.txt
@@ -1,0 +1,2 @@
+Name: Erdawati Bte Ellias
+I am taking Code Management in DevOps! :)

--- a/Students/Erdawati_details.txt
+++ b/Students/Erdawati_details.txt
@@ -1,2 +1,2 @@
-Name: Erdawati Bte Ellias
+Name: Erdawati Ellias
 I am taking Code Management in DevOps! :)

--- a/Students/student_details.txt
+++ b/Students/student_details.txt
@@ -2,9 +2,9 @@ There are 6 students in total for this class.
 For each student, we will store their names and current score for the class.
 The students are currently arranged based on decreasing order of their score.
 
-1. James (91%)
-2. Tim (83%)
-3. Samantha (81%)
-4. Paul (75%)
-5. Rea (70%)
-6. Lenny (66%)
+1. James (90%)
+2. Tim (82%)
+3. Samantha (80%)
+4. Paul (74%)
+5. Rea (69%)
+6. Lenny (65%)

--- a/Students/student_details.txt
+++ b/Students/student_details.txt
@@ -1,4 +1,4 @@
-There are 6 students in total for this class.
+There are 7 students in total for this class.
 For each student, we will store their names and current score for the class.
 The students are currently arranged based on decreasing order of their score.
 

--- a/Students/student_details.txt
+++ b/Students/student_details.txt
@@ -3,8 +3,9 @@ For each student, we will store their names and current score for the class.
 The students are currently arranged based on decreasing order of their score.
 
 1. James (91%)
-2. Tim (83%)
-3. Samantha (81%)
-4. Paul (75%)
-5. Rea (70%)
-6. Lenny (66%)
+2. Erdawati (85%)
+3. Tim (83%)
+4. Samantha (81%)
+5. Paul (75%)
+6. Rea (70%)
+7. Lenny (66%)


### PR DESCRIPTION
Student scores were wrongly calculated initially and were each higher than their actual score by 1. The actual score is now updated with the correct values.